### PR TITLE
Various changes and fixes

### DIFF
--- a/runtime/menu.vim
+++ b/runtime/menu.vim
@@ -75,6 +75,7 @@ if has("gui_macvim")
   an <silent> 9998.311 Window.Zoom\ All		    <Nop>
   an <silent> 9998.320 Window.Toggle\ Full\ Screen\ Mode :set invfullscreen<CR>
   an <silent> 9998.325 Window.Toggle\ File\ Browser <Nop>
+  an <silent> 9998.326 Window.Select\ File\ In\ Browser   <Nop>
   an 9998.330 Window.-SEP1-			    <Nop>
   " TODO! Grey out if no tabs are visible.
   an <silent> 9998.340 Window.Select\ Next\ Tab	    :tabnext<CR>
@@ -1218,6 +1219,7 @@ if has("gui_macvim")
   macm Window.Zoom\ All		key=<D-M-C-z>	action=zoomAll:		alt=YES
   macm Window.Toggle\ Full\ Screen\ Mode	key=<D-F>
   macm Window.Toggle\ File\ Browser key=<D-E>   action=toggleDrawer:
+  macm Window.Select\ File\ In\ Browser key=<D-M-e>   action=selectInDrawer:
   macm Window.Select\ Next\ Tab			key=<D-}>
   macm Window.Select\ Previous\ Tab		key=<D-{>
   macm Window.Bring\ All\ To\ Front		action=arrangeInFront:

--- a/src/MacVim/Actions.plist
+++ b/src/MacVim/Actions.plist
@@ -70,6 +70,8 @@
 	<string></string>
 	<key>toggleDrawer:</key>
 	<string></string>
+	<key>selectInDrawer:</key>
+	<string></string>
 	<key>undo:</key>
 	<string></string>
 	<key>unhide:</key>

--- a/src/MacVim/MMFileDrawerController.h
+++ b/src/MacVim/MMFileDrawerController.h
@@ -17,7 +17,7 @@
 - (void)open;
 - (void)close;
 - (void)toggle;
-- (void)selectCurrentBuffer;
+- (void)selectInDrawer;
 
 - (NSMenu *)menuForRow:(NSInteger)row;
 

--- a/src/MacVim/MMFileDrawerController.h
+++ b/src/MacVim/MMFileDrawerController.h
@@ -17,6 +17,7 @@
 - (void)open;
 - (void)close;
 - (void)toggle;
+- (void)selectCurrentBuffer;
 
 - (NSMenu *)menuForRow:(NSInteger)row;
 

--- a/src/MacVim/MMFileDrawerController.m
+++ b/src/MacVim/MMFileDrawerController.m
@@ -402,7 +402,6 @@ static NSMutableArray *leafNode = nil;
   [scrollView setAutohidesScrollers:YES];
   [scrollView setDocumentView:filesView];
 
-  /* scrollView.frame = CGRectMake(0, pathComponentsPopup.frame.size.height, 0, 0); */
   scrollView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable | NSViewMaxYMargin;
 
   [drawerView addSubview:scrollView];
@@ -916,8 +915,8 @@ static void change_occured(ConstFSEventStreamRef stream,
   [[NSNotificationCenter defaultCenter] removeObserver:self];
 
   [self unwatchRoot];
-  [rootItem release];
   [drawer release];
+  [rootItem release];
   [pathComponentsPopup release];
 
   [super dealloc];

--- a/src/MacVim/MMFileDrawerController.m
+++ b/src/MacVim/MMFileDrawerController.m
@@ -396,14 +396,14 @@ static NSMutableArray *leafNode = nil;
   pathComponentsPopup = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(0, 0, 0, 25)];
   pathComponentsPopup.autoresizingMask = NSViewWidthSizable;
 
-  NSScrollView *scrollView = [[[NSScrollView alloc] initWithFrame:NSZeroRect] autorelease];
+  NSScrollView *scrollView = [[[NSScrollView alloc] initWithFrame:NSMakeRect(0, 25, 0, 0)] autorelease];
   [scrollView setHasHorizontalScroller:YES];
   [scrollView setHasVerticalScroller:YES];
   [scrollView setAutohidesScrollers:YES];
   [scrollView setDocumentView:filesView];
   
-  scrollView.frame = CGRectMake(0, pathComponentsPopup.frame.size.height, 0, 0);
-  scrollView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+  /* scrollView.frame = CGRectMake(0, pathComponentsPopup.frame.size.height, 0, 0); */
+  scrollView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable | NSViewMaxYMargin;
   
   [drawerView addSubview:scrollView];
   [drawerView addSubview:pathComponentsPopup];

--- a/src/MacVim/MMFileDrawerController.m
+++ b/src/MacVim/MMFileDrawerController.m
@@ -64,7 +64,7 @@ static NSMutableArray *leafNode = nil;
     icon = nil;
     path = [thePath retain];
     parent = parentItem;
-    vim = [vimInstance retain];
+    vim = vimInstance;
     if (parent) {
       includesHiddenFiles = parent.includesHiddenFiles;
       useWildIgnore = parent.useWildIgnore;
@@ -276,7 +276,7 @@ static NSMutableArray *leafNode = nil;
   }
   [path release];
   [icon release];
-  [vim release];
+  vim = nil;
   [super dealloc];
 }
 

--- a/src/MacVim/MMFileDrawerController.m
+++ b/src/MacVim/MMFileDrawerController.m
@@ -376,10 +376,10 @@ static NSMutableArray *leafNode = nil;
 
   drawer = [[NSDrawer alloc] initWithContentSize:NSMakeSize(200, 0)
                                    preferredEdge:edge];
-  
+
   FlippedView *drawerView = [[[FlippedView alloc] initWithFrame:NSZeroRect] autorelease];
   drawerView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
-  
+
   FilesOutlineView *filesView = [[[FilesOutlineView alloc] initWithFrame:NSZeroRect] autorelease];
   [filesView setDelegate:self];
   [filesView setDataSource:self];
@@ -401,17 +401,17 @@ static NSMutableArray *leafNode = nil;
   [scrollView setHasVerticalScroller:YES];
   [scrollView setAutohidesScrollers:YES];
   [scrollView setDocumentView:filesView];
-  
+
   /* scrollView.frame = CGRectMake(0, pathComponentsPopup.frame.size.height, 0, 0); */
   scrollView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable | NSViewMaxYMargin;
-  
+
   [drawerView addSubview:scrollView];
   [drawerView addSubview:pathComponentsPopup];
   [drawer setContentView:drawerView];
 
   [self setView:filesView];
   [self updatePathComponentsPopup];
-  
+
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(pwdChanged:)
                                                name:@"MMPwdChanged"
@@ -554,32 +554,32 @@ static NSMutableArray *leafNode = nil;
   NSString *path = [rootItem fullPath];
   NSFileManager *fileManager = [NSFileManager defaultManager];
   NSMenu *menu = [[[NSMenu alloc] init] autorelease];
-  
+
   NSArray *pathComponents = [path pathComponents];
   int i;
   int pathLen = [pathComponents count];
   for (i = pathLen; i > 0; i--) {
     NSArray *subPathComponents = [pathComponents subarrayWithRange:NSMakeRange(0, i)];
     NSString *subPath = [NSString pathWithComponents:subPathComponents];
-    
+
     NSMenuItem *item = [[[NSMenuItem alloc] initWithTitle:[fileManager displayNameAtPath:subPath] action:@selector(changeWorkingDirectoryToSelection:) keyEquivalent:@""] autorelease];
     [item setTarget:self];
     [item setRepresentedObject:subPath];
-    
+
     NSImage *icon = [[NSWorkspace sharedWorkspace] iconForFile:subPath];
     [icon setSize:NSMakeSize(16, 16)];
     [item setImage:icon];
 
     [menu addItem:item];
   }
-  
+
   [pathComponentsPopup setMenu:menu];
   [pathComponentsPopup selectItemAtIndex:0];
 }
 
 // Data Source methods
 // ===================
- 
+
 - (NSInteger)outlineView:(NSOutlineView *)outlineView numberOfChildrenOfItem:(id)item {
   if (item == nil) {
     item = rootItem;
@@ -604,7 +604,7 @@ static NSMutableArray *leafNode = nil;
 - (id)outlineView:(NSOutlineView *)outlineView objectValueForTableColumn:(NSTableColumn *)tableColumn byItem:(id)item {
   if (item == nil) {
     item = rootItem;
-  }  
+  }
   return [item relativePath];
 }
 
@@ -868,7 +868,11 @@ static void change_occured(ConstFSEventStreamRef stream,
     // NSLog(@"Change occurred in path: %@", [item fullPath]);
     // No need to reload recursive, the change occurred in *this* item only
     if ([item reloadRecursive:NO]) {
-      [[self outlineView] reloadItem:item reloadChildren:YES];
+      if(rootItem == item) {
+        [[self outlineView] reloadData];
+      }
+      else
+        [[self outlineView] reloadItem:item reloadChildren:YES];
     }
   }
 }
@@ -876,7 +880,7 @@ static void change_occured(ConstFSEventStreamRef stream,
 - (void)watchRoot {
   NSString *path = [rootItem fullPath];
   // NSLog(@"Watch: %@", path);
-  
+
   FSEventStreamContext context;
   context.version = 0;
   context.info = (void *)self;

--- a/src/MacVim/MMFileDrawerController.m
+++ b/src/MacVim/MMFileDrawerController.m
@@ -475,15 +475,16 @@ static NSMutableArray *leafNode = nil;
   [drawer setParentWindow:[windowController window]];
   [drawer toggle:self];
 
-  if([drawer state] == NSDrawerOpeningState)
-    [self selectCurrentBuffer];
+    [self selectInDrawer];
 }
 
-- (void)selectCurrentBuffer {
-  NSString *bufName = [[windowController vimController]
+- (void)selectInDrawer {
+  if([drawer state] != NSDrawerOpeningState && [drawer state] != NSDrawerOpenState)
+    return;
+  NSString *fn = [[windowController vimController]
                                                   evaluateVimExpression:@"expand('%:p')"];
-  if([bufName length] > 0) {
-    FileSystemItem *item = [rootItem itemAtPath:bufName];
+  if([fn length] > 0) {
+    FileSystemItem *item = [rootItem itemAtPath:fn];
     [[self outlineView] selectItem:item];
   }
 }

--- a/src/MacVim/MMFileDrawerController.m
+++ b/src/MacVim/MMFileDrawerController.m
@@ -911,10 +911,10 @@ static void change_occured(ConstFSEventStreamRef stream,
 - (void)dealloc {
   [[NSNotificationCenter defaultCenter] removeObserver:self];
 
-  [drawer release];
-  [rootItem release];
-  [pathComponentsPopup release];
   [self unwatchRoot];
+  [rootItem release];
+  [drawer release];
+  [pathComponentsPopup release];
 
   [super dealloc];
 }

--- a/src/MacVim/MMFileDrawerController.m
+++ b/src/MacVim/MMFileDrawerController.m
@@ -790,7 +790,10 @@ static NSMutableArray *leafNode = nil;
   FileSystemItem *dirItem = item.parent;
   [[NSFileManager defaultManager] removeItemAtPath:[item fullPath] error:NULL];
   [dirItem reloadRecursive:NO];
-  [[self outlineView] reloadItem:dirItem reloadChildren:YES];
+  if(rootItem == dirItem)
+    [[self outlineView] reloadData];
+  else
+    [[self outlineView] reloadItem:dirItem reloadChildren:YES];
   dirItem.ignoreNextReload = YES;
 }
 

--- a/src/MacVim/MMWindowController.h
+++ b/src/MacVim/MMWindowController.h
@@ -99,5 +99,6 @@
 - (IBAction)openDrawer:(id)sender;
 - (IBAction)closeDrawer:(id)sender;
 - (IBAction)toggleDrawer:(id)sender;
+- (IBAction)selectInDrawer:(id)sender;
 
 @end

--- a/src/MacVim/MMWindowController.m
+++ b/src/MacVim/MMWindowController.m
@@ -976,6 +976,12 @@
     [fileDrawerController toggle];
 }
 
+- (IBAction)selectInDrawer:(id)sender
+{
+    [fileDrawerController open];
+    [fileDrawerController selectCurrentBuffer];
+}
+
 
 // -- Services menu delegate -------------------------------------------------
 

--- a/src/MacVim/MMWindowController.m
+++ b/src/MacVim/MMWindowController.m
@@ -978,8 +978,7 @@
 
 - (IBAction)selectInDrawer:(id)sender
 {
-    [fileDrawerController open];
-    [fileDrawerController selectCurrentBuffer];
+    [fileDrawerController selectInDrawer];
 }
 
 


### PR DESCRIPTION
Please consider this pull. 

Added:
1. selectInDrawer: action to select a file loaded in the active buffer in the file drawer. This way it's possible to use autocmd like this:
   
   au WinEnter,BufEnter \* macaction selectInDrawer:
2. selectInDrawer: is called automatically when the drawer is opened
3. Added a new menu 'Window/Select File in Drawer' for this action
4. Filter files based on vim's wildignore option
5. Font size is reduced to 11 points. (Personal preference, could be reverted)

Fixes latest changes with new pathComponentPopup:
1. ScollView doesn't fit into the drawer viewport and is displayed clipped at the bottom
2. Since the rootItem is not displayed anymore, changes to the working directory are not being updated in the drawer.

Let me know if you have any questions. Thanks.
