### PR TITLE
Fix for MMVimController#addInput method

### DIFF
--- a/src/MacVim/MMBackend.m
+++ b/src/MacVim/MMBackend.m
@@ -1265,14 +1265,16 @@ extern GuiFont gui_mch_retain_font(GuiFont font);
         // queue, else the input queue may fill up as a result of Vim not being
         // able to keep up with the speed at which new messages are received.
         // TODO: Remove all previous instances (there could be many)?
-        int i, count = [inputQueue count];
-        for (i = 1; i < count; i += 2) {
-            if ([[inputQueue objectAtIndex:i-1] intValue] == msgid) {
-                ASLogDebug(@"Input queue filling up, remove message: %s",
-                                                        MessageStrings[msgid]);
-                [inputQueue removeObjectAtIndex:i];
-                [inputQueue removeObjectAtIndex:i-1];
-                break;
+        if(AddInputMsgID != msgid) {
+            int i, count = [inputQueue count];
+            for (i = 1; i < count; i += 2) {
+                if ([[inputQueue objectAtIndex:i-1] intValue] == msgid) {
+                    ASLogDebug(@"Input queue filling up, remove message: %s",
+                            MessageStrings[msgid]);
+                    [inputQueue removeObjectAtIndex:i];
+                    [inputQueue removeObjectAtIndex:i-1];
+                    break;
+                }
             }
         }
 


### PR DESCRIPTION
I've noticed that file renaming doesn't work correctly. 

When a file is renamed, the old buffer must be deleted with `bwipe!` and a new buffer with a renamed file should be opened. `MMFileBrowserController` implements this functionality correctly by sending two messages consequently via `MMVimController#addInput`. The fist message is to call `MMDeleteBufferByPath` vim function and the second message is `:edit [new_file_name]'. Unfortunately, only the last message gets processed since MMBackend removes all the previous messages with the same ID as an optimization step. 

This patch excludes this optimization for `AddInputMsgID` messages. 

Please review.
