### PR TITLE
fixed compiler error

### DIFF
--- a/src/os_unix.c
+++ b/src/os_unix.c
@@ -25,6 +25,8 @@
  * Don't use it for the Mac, it causes a warning for precompiled headers.
  * TODO: use a configure check for precompiled headers?
  */
+#include <AvailabilityMacros.h>
+
 #if !defined(__APPLE__) && !defined(__TANDEM)
 # define select select_declared_wrong
 #endif


### PR DESCRIPTION
This change fixed a compiler error on mac os 10.9.

```
gcc -c -I. -Iproto -DHAVE_CONFIG_H -DFEAT_GUI_MACVIM -Wall -Wno-unknown-pragmas -pipe  -DMACOS_X_UNIX -no-cpp-precomp  -g -O2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1       -o objects/os_unix.o os_unix.c
os_unix.c:830:46: warning: declaration of 'struct sigaltstack' will not be visible outside of this function [-Wvisibility]
        extern int sigaltstack __ARGS((const struct sigaltstack *ss, struct sigaltstack *oss));
                                                    ^
./os_unix.h:88:21: note: expanded from macro '__ARGS'
#  define __ARGS(x) x
                    ^
os_unix.c:830:13: error: conflicting types for 'sigaltstack'
        extern int sigaltstack __ARGS((const struct sigaltstack *ss, struct sigaltstack *oss));
                   ^
/usr/include/signal.h:85:5: note: previous declaration is here
int     sigaltstack(const stack_t * __restrict, stack_t * __restrict)  __DARWIN_ALIAS(sigaltstack);
        ^
1 warning and 1 error generated.
make: *** [objects/os_unix.o] Error 1
```
